### PR TITLE
Removed modal functions from landing page, added things to Redux store

### DIFF
--- a/src/components/AddNodeForm.js
+++ b/src/components/AddNodeForm.js
@@ -2,41 +2,37 @@ import React, {Component} from 'react';
 import {Text, View, Modal, TextInput} from 'react-native';
 import {CardSection} from './common/CardSection';
 import {Button} from './common/Button';
+import {Input} from './common/Input';
 
+export default function AddNodeForm (props){
+    console.log('addNodeForm props', props)
+    const { containerStyle, textStyle, cardSectionStyle} = styles;
 
-export default function AddNodeForm (props) {
-        const { containerStyle, textStyle, cardSectionStyle, inputStyle } = styles;
-        return (
-            <Modal
-                visible={props.visible}
-                transparent
-                animationType="fade"
-                onRequestClose={() => {
-                }}
-            >
-                <View style={containerStyle}>
-                    <CardSection style={cardSectionStyle}>
-                        <Text style={textStyle}>
-                            {props.children}
-                        </Text>
-                    </CardSection>
-                    <TextInput
-                        style={inputStyle}
-                        name='text'
+    return (
+        <Modal
+            visible={props.visible}
+            transparent
+            animationType="fade"
+            onRequestClose={() => {}}
+        >
+            <View style={containerStyle}>
+                <CardSection>
+                    <Input
+                        label="Directions to your new Egg"
                         onChangeText={e => props.handleInputChange(e)}
                         value={props.text}
+                        onFocus={props.clearInput}
                     />
+                </CardSection>
+                <CardSection>
+                    <Button onPress={props.onSubmitNode}>Submit</Button>
+                    <Button onPress={props.onCancelSubmitNode}>Cancel</Button>
+                </CardSection>
+            </View>
+        </Modal>
+    )
+}
 
-                    <CardSection>
-                        <Button onPress={props.onSubmitNode}>Submit</Button>
-                        <Button onPress={props.onCancelSubmitNode}>Cancel</Button>
-                    </CardSection>
-                </View>
-            </Modal>
-        );
-
-
-};
 
 const styles = {
     cardSectionStyle: {
@@ -54,13 +50,6 @@ const styles = {
         flex: 1,
         justifyContent: 'center'
     },
-    inputStyle:{
-        height: 40,
-        borderColor: 'gray',
-        backgroundColor:'white',
-        borderWidth: 1
-    }
 };
-
 
 

--- a/src/components/AddNodeForm.js
+++ b/src/components/AddNodeForm.js
@@ -6,14 +6,13 @@ import {Input} from './common/Input';
 import { connect } from 'react-redux';
 import axios from 'axios';
 import {showModal} from '../reducers/addNodeModal'
-
+import {setAnnotations, addAnnotation} from '../reducers/map'
 
 
 class AddNodeForm extends Component {
     constructor(props){
         super(props);
         this.state = {
-            annotations:[],
             text: 'placeholder'
         };
 
@@ -40,9 +39,15 @@ class AddNodeForm extends Component {
             latitude: this.props.annotations[0].latitude,
             longitude: this.props.annotations[0].longitude
         }
-        axios.post('http://localhost:1333/api/egg', egg);
-        this.setState({ annotations: [],  text:'placeholder' });
-        this.props.showModal(false);
+        axios.post('http://localhost:1333/api/egg', egg)
+            .then(()=>{
+                this.setState({ text:'placeholder' });
+                this.props.showModal(false);
+                //this line below causes the app to crash, possibly an async issue with the axios post above
+                // this.props.setAnnotations([]);
+            })
+
+
     }
 
     onCancelSubmitNode() {
@@ -95,7 +100,8 @@ const styles = StyleSheet.create({
 
 const mapStateToProps = (state, ownProps) => {
     return {
-        showAddNodeModal: state.addNodeModal.showAddNodeModal
+        showAddNodeModal: state.addNodeModal.showAddNodeModal,
+        annotations: state.map.annotations
     };
 }
 
@@ -105,6 +111,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         showModal: function(boolean){
             dispatch(showModal(boolean));
         },
+        setAnnotations: function(annotations){
+            dispatch(setAnnotations(annotations))
+        },
+        addAnnotation: function(annotation){
+            dispatch(addAnnotation(annotation))
+        }
     }
 }
 

--- a/src/components/AddNodeForm.js
+++ b/src/components/AddNodeForm.js
@@ -1,40 +1,80 @@
 import React, {Component} from 'react';
-import {Text, View, Modal, TextInput} from 'react-native';
+import {Text, View, Modal, TextInput, StyleSheet} from 'react-native';
 import {CardSection} from './common/CardSection';
 import {Button} from './common/Button';
 import {Input} from './common/Input';
+import { connect } from 'react-redux';
+import axios from 'axios';
+import {showModal} from '../reducers/addNodeModal'
 
-export default function AddNodeForm (props){
-    console.log('addNodeForm props', props)
-    const { containerStyle, textStyle, cardSectionStyle} = styles;
 
-    return (
-        <Modal
-            visible={props.visible}
-            transparent
-            animationType="fade"
-            onRequestClose={() => {}}
-        >
+
+class AddNodeForm extends Component {
+    constructor(props){
+        super(props);
+        this.state = {
+            annotations:[],
+            text: 'placeholder'
+        };
+
+        this.handleInputChange=this.handleInputChange.bind(this);
+        this.clearInput=this.clearInput.bind(this);
+        this.onSubmitNode = this.onSubmitNode.bind(this);
+        this.onCancelSubmitNode = this.onCancelSubmitNode.bind(this);
+    }
+
+
+    handleInputChange(e){
+        this.setState({text: e });
+    }
+
+    clearInput(){
+        this.setState({text:''});
+    }
+
+    onSubmitNode() {
+        console.log("submitted");
+        //send data to DB
+        const egg = {
+            goHereText: this.state.text,
+            latitude: this.props.annotations[0].latitude,
+            longitude: this.props.annotations[0].longitude
+        }
+        axios.post('http://localhost:1333/api/egg', egg);
+        this.setState({ annotations: [],  text:'placeholder' });
+        this.props.showModal(false);
+    }
+
+    onCancelSubmitNode() {
+        this.setState({ text:'placeholder' });
+        this.props.showModal(false);
+
+    }
+
+    render(){
+        const { containerStyle, textStyle, cardSectionStyle} = styles;
+
+        return (
             <View style={containerStyle}>
                 <CardSection>
                     <Input
                         label="Directions to your new Egg"
-                        onChangeText={e => props.handleInputChange(e)}
-                        value={props.text}
-                        onFocus={props.clearInput}
+                        onChangeText={e => this.handleInputChange(e)}
+                        value={this.state.text}
+                        onFocus={this.clearInput}
                     />
                 </CardSection>
                 <CardSection>
-                    <Button onPress={props.onSubmitNode}>Submit</Button>
-                    <Button onPress={props.onCancelSubmitNode}>Cancel</Button>
+                    <Button onPress={this.onSubmitNode}>Submit</Button>
+                    <Button onPress={this.onCancelSubmitNode}>Cancel</Button>
                 </CardSection>
             </View>
-        </Modal>
-    )
+        )
+    }
 }
 
 
-const styles = {
+const styles = StyleSheet.create({
     cardSectionStyle: {
         justifyContent: 'center'
     },
@@ -50,6 +90,22 @@ const styles = {
         flex: 1,
         justifyContent: 'center'
     },
-};
+});
 
 
+const mapStateToProps = (state, ownProps) => {
+    return {
+        showAddNodeModal: state.addNodeModal.showAddNodeModal
+    };
+}
+
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+    return {
+        showModal: function(boolean){
+            dispatch(showModal(boolean));
+        },
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AddNodeForm);

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -6,6 +6,7 @@ import { Button } from './common';
 import  AddNodeForm  from './AddNodeForm';
 import { connect } from 'react-redux';
 import {showModal} from '../reducers/addNodeModal'
+import {setAnnotations, addAnnotation} from '../reducers/map'
 
 
 class LandingPage extends Component {
@@ -14,7 +15,6 @@ class LandingPage extends Component {
     super(props);
     this.state = {
       currentPosition: { timestamp: 0, coords: { latitude: 1, longitude: 1 } },
-      annotations: [],
     };
 
     this.onMapLongPress = this.onMapLongPress.bind(this);
@@ -41,7 +41,7 @@ class LandingPage extends Component {
   }
 
   onMapLongPress(event) {
-    if (!this.state.annotations.length) {
+    if (!this.props.annotations.length) {
       let options = {
         enableHighAccuracy: true,
         timeout: 5000,
@@ -50,9 +50,11 @@ class LandingPage extends Component {
 
       navigator.geolocation.getCurrentPosition(
         (position) => {
-          this.setState({
-              annotations: [this.createAnnotation(position.coords.longitude, position.coords.latitude)]
-            })
+          let newA = this.createAnnotation(position.coords.longitude, position.coords.latitude);
+          this.props.setAnnotations(newA);
+          // this.setState({
+          //     annotations: [this.createAnnotation(position.coords.longitude, position.coords.latitude)]
+          //   })
         }
         , null, options);
     }
@@ -65,16 +67,18 @@ class LandingPage extends Component {
       draggable: true,
       onDragStateChange: (event) => {
         if (event.state === 'idle') {
-          this.setState({
-            annotations: [this.createAnnotation(event.longitude, event.latitude)]
-          });
+          let newAnnotation= this.createAnnotation(event.longitude, event.latitude);
+          this.props.setAnnotations(newAnnotation);
+          // this.setState({
+          //   annotations: [this.createAnnotation(event.longitude, event.latitude)]
+          // });
         }
       },
     };
   }
 
   renderLeavePackageButton() {
-    if (this.state.annotations.length) {
+    if (this.props.annotations.length) {
       return (
         <Button onPress={this.onAddNodeButtonPress.bind(this)}>
         Leave an egg at the current pin
@@ -85,7 +89,7 @@ class LandingPage extends Component {
 
   render() {
     const position = this.state.currentPosition;
-    const annotations = this.state.annotations;
+    const annotations = this.props.annotations;
 
     return (
       <View>
@@ -130,7 +134,8 @@ const styles = StyleSheet.create({
 const mapStateToProps = (state, ownProps) => {
   console.log('landing page, mstp, state', state)
     return {
-        showAddNodeModal: state.addNodeModal.showAddNodeModal
+        showAddNodeModal: state.addNodeModal.showAddNodeModal,
+        annotations: state.map.annotations
     };
 }
 
@@ -141,6 +146,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         showModal: function(boolean){
             dispatch(showModal(boolean));
         },
+        setAnnotations: function(annotations){
+          dispatch(setAnnotations(annotations))
+        },
+        addAnnotation: function(annotation){
+          dispatch(addAnnotation(annotation))
+        }
     }
 }
 

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import React, { Component } from 'react';
-import { View, Text, StyleSheet, MapView, TextInput, TouchableWithoutFeedback } from 'react-native';
-import { Button, Input } from './common';
+import { View, Text, StyleSheet, MapView, TextInput, TouchableWithoutFeedback, Modal } from 'react-native';
+import { Button } from './common';
 import  AddNodeForm  from './AddNodeForm';
 import { connect } from 'react-redux';
-import axios from 'axios';
+import {showModal} from '../reducers/addNodeModal'
 
 
 class LandingPage extends Component {
@@ -14,16 +14,10 @@ class LandingPage extends Component {
     super(props);
     this.state = {
       currentPosition: { timestamp: 0, coords: { latitude: 1, longitude: 1 } },
-      showAddNodeModal: false,
       annotations: [],
-      text: 'placeholder'
     };
 
-    this.onSubmitNode = this.onSubmitNode.bind(this);
-    this.onCancelSubmitNode = this.onCancelSubmitNode.bind(this);
     this.onMapLongPress = this.onMapLongPress.bind(this);
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.clearInput=this.clearInput.bind(this);
 }
 
   componentDidMount() {
@@ -31,31 +25,7 @@ class LandingPage extends Component {
   }
 
   onAddNodeButtonPress() {
-    this.setState({ showAddNodeModal: true })
-  }
-
-  onSubmitNode() {
-    console.log("submitted");
-    //send data to DB
-    const egg = {
-      goHereText: this.state.text,
-      latitude: this.state.annotations[0].latitude,
-      longitude: this.state.annotations[0].longitude
-    }
-    axios.post('http://localhost:1333/api/egg', egg);
-    this.setState({ showAddNodeModal: false, annotations: [],  text:'placeholder' });
-  }
-
-  onCancelSubmitNode() {
-    this.setState({ showAddNodeModal: false, text:'placeholder' });
-  }
-
-  handleInputChange(e){
-      this.setState({text: e });
-  }
-
-  clearInput(){
-    this.setState({text:''});
+    this.props.showModal(true);
   }
 
   updateCurrentPosition() {
@@ -130,16 +100,19 @@ class LandingPage extends Component {
         
         {this.renderLeavePackageButton()}
 
-        <AddNodeForm
-          visible={ this.state.showAddNodeModal }
-          onSubmitNode={ this.onSubmitNode }
-          onCancelSubmitNode={ this.onCancelSubmitNode }
-          handleInputChange={this.handleInputChange}
-          clearInput={this.clearInput}
-          {...this.state}
+        <Modal
+            visible={this.props.showAddNodeModal}
+            transparent
+            animationType="fade"
+            onRequestClose={() => {
+            }}
         >
+          <AddNodeForm
+              {...this.state}>
+          </AddNodeForm>
+        </Modal>
 
-        </AddNodeForm>
+
         
 
       </View>
@@ -155,7 +128,9 @@ const styles = StyleSheet.create({
 
 
 const mapStateToProps = (state, ownProps) => {
+  console.log('landing page, mstp, state', state)
     return {
+        showAddNodeModal: state.addNodeModal.showAddNodeModal
     };
 }
 
@@ -163,8 +138,8 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
     return {
-        addUToDb: function(user){
-            dispatch(addUToDb(user));
+        showModal: function(boolean){
+            dispatch(showModal(boolean));
         },
     }
 }

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 import { View, Text, StyleSheet, MapView, TextInput, TouchableWithoutFeedback } from 'react-native';
-import { Button } from './common';
+import { Button, Input } from './common';
 import  AddNodeForm  from './AddNodeForm';
 import { connect } from 'react-redux';
 import axios from 'axios';
@@ -22,7 +22,8 @@ class LandingPage extends Component {
     this.onSubmitNode = this.onSubmitNode.bind(this);
     this.onCancelSubmitNode = this.onCancelSubmitNode.bind(this);
     this.onMapLongPress = this.onMapLongPress.bind(this);
-    this.handleInputChange = this.handleInputChange.bind(this); 
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.clearInput=this.clearInput.bind(this);
 }
 
   componentDidMount() {
@@ -42,15 +43,19 @@ class LandingPage extends Component {
       longitude: this.state.annotations[0].longitude
     }
     axios.post('http://localhost:1333/api/egg', egg);
-    this.setState({ showAddNodeModal: false, annotations: [] });
+    this.setState({ showAddNodeModal: false, annotations: [],  text:'placeholder' });
   }
 
   onCancelSubmitNode() {
-    this.setState({ showAddNodeModal: false });
+    this.setState({ showAddNodeModal: false, text:'placeholder' });
   }
 
   handleInputChange(e){
       this.setState({text: e });
+  }
+
+  clearInput(){
+    this.setState({text:''});
   }
 
   updateCurrentPosition() {
@@ -130,9 +135,10 @@ class LandingPage extends Component {
           onSubmitNode={ this.onSubmitNode }
           onCancelSubmitNode={ this.onCancelSubmitNode }
           handleInputChange={this.handleInputChange}
+          clearInput={this.clearInput}
           {...this.state}
         >
-          BUK BUK BUK...
+
         </AddNodeForm>
         
 

--- a/src/components/common/Input.js
+++ b/src/components/common/Input.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {TextInput, View, Text} from 'react-native';
 
-const Input = ({label, value, onChangeText, placeholder, secureTextEntry}) => {
+const Input = ({label, value, onChangeText, placeholder, secureTextEntry, onFocus}) => {
 	const {inputStyle, labelStyle, containerStyle} = styles;
 	return (
 	<View style={containerStyle}>
@@ -12,7 +12,8 @@ const Input = ({label, value, onChangeText, placeholder, secureTextEntry}) => {
 		autoCorrect={false}
 		style={inputStyle}
 		value={value}
-		onChangeText={onChangeText} />
+		onChangeText={onChangeText}
+		onFocus={onFocus}/>
 	</View>
 	);
 }

--- a/src/reducers/addNodeModal.js
+++ b/src/reducers/addNodeModal.js
@@ -1,0 +1,33 @@
+import React from 'react'
+
+const SHOW_MODAL = 'SHOW_MODAL';
+
+///Determine whether to show the AddNodeModal or not
+
+const initialState = {
+    showAddNodeModal: false,
+}
+
+//Action
+export const showModal = function (boolean) {
+    return {
+        type: SHOW_MODAL,
+        showAddNodeModal: boolean
+    };
+};
+
+
+
+/// Reducer
+export default function (state = initialState, action) {
+    let newState = Object.assign({}, state)
+    switch (action.type) {
+        case SHOW_MODAL:
+            newState.showAddNodeModal = action.showAddNodeModal;
+            break;
+        default:
+            return state;
+    }
+
+    return newState;
+}

--- a/src/reducers/eggs.js
+++ b/src/reducers/eggs.js
@@ -4,7 +4,7 @@ const ADD_EGG = 'ADD_EGG';
 
 const initialState = {
     allEggs: [],
-    selectedEgg: {}
+    selectedEgg: {},
 }
 
 

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -1,0 +1,43 @@
+import React from 'react'
+
+const SET_ANNOTATIONS = 'SET_ANNOTATIONS';
+const ADD_ANNOTATION = 'ADD_ANNOTATION';
+
+
+const initialState = {
+    annotations: []
+}
+
+//Action
+export const setAnnotations = function (annotations) {
+    return {
+        type: SET_ANNOTATIONS,
+        annotations: annotations
+    };
+};
+
+export const addAnnotation = function (annotation) {
+    return {
+        type: ADD_ANNOTATION,
+        annotation: annotation
+    };
+};
+
+
+
+/// Reducer
+export default function (state = initialState, action) {
+    let newState = Object.assign({}, state)
+    switch (action.type) {
+        case SET_ANNOTATIONS:
+            newState.annotations = [action.annotations];
+            break;
+        case ADD_ANNOTATION:
+            newState.annotations = [...newState.annotations, action.annotation];
+            break;
+        default:
+            return state;
+    }
+
+    return newState;
+}

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -2,9 +2,10 @@ import { combineReducers } from 'redux'
 //import reducers
 import eggs from './eggs';
 import addNodeModal from './addNodeModal';
+import map from './map';
 
 
 
-const rootReducer = combineReducers({eggs, addNodeModal})
+const rootReducer = combineReducers({eggs, addNodeModal, map})
 
 export default rootReducer

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -1,9 +1,10 @@
 import { combineReducers } from 'redux'
 //import reducers
 import eggs from './eggs';
+import addNodeModal from './addNodeModal';
 
 
 
-const rootReducer = combineReducers({eggs})
+const rootReducer = combineReducers({eggs, addNodeModal})
 
 export default rootReducer


### PR DESCRIPTION
I didn't like the modal code cluttering up the landing page code, so I moved it all into the AddNodeModalForm, and that led to a cascade of changes, the most important being that I added several things to the Redux store - a boolean that will tell us whether to show the AddNodeModal or not, as well as the annotations.  